### PR TITLE
Added retry logic for pulling certificate

### DIFF
--- a/setupWinRm.ps1
+++ b/setupWinRm.ps1
@@ -20,9 +20,9 @@ param
   $rootCertName
 )
 
-Write-Host "Current Time: $(Get-Date -Format o)"
-
 Start-Transcript -Path C:\Temp\setupWinRm.log
+
+Write-Host "Current Time: $(Get-Date -Format o)"
 
 if (-not (Get-LocalGroupMember -Group "Administrators" -Member "*$($svcAccount)*" -ErrorAction SilentlyContinue)) {
   Add-LocalGroupMember -Group "Administrators" -Member "$svcAccount"

--- a/setupWinRm.ps1
+++ b/setupWinRm.ps1
@@ -22,6 +22,8 @@ param
 
 Start-Transcript -Path C:\Temp\setupWinRm.log
 
+W32tm /resync /force
+
 Write-Host "Current Time: $(Get-Date -Format o)"
 
 if (-not (Get-LocalGroupMember -Group "Administrators" -Member "*$($svcAccount)*" -ErrorAction SilentlyContinue)) {

--- a/setupWinRm.ps1
+++ b/setupWinRm.ps1
@@ -20,6 +20,8 @@ param
   $rootCertName
 )
 
+Write-Host "Current Time: $(Get-Date -Format o)"
+
 Start-Transcript -Path C:\Temp\setupWinRm.log
 
 if (-not (Get-LocalGroupMember -Group "Administrators" -Member "*$($svcAccount)*" -ErrorAction SilentlyContinue)) {
@@ -44,7 +46,28 @@ while ($count -le 30) {
 $IP = (Get-NetIPAddress -InterfaceAlias "Ethernet0*" -AddressFamily IPv4).IPAddress
 $ShortName = "$($Env:COMPUTERNAME)"
 $FQDN = "$($Env:COMPUTERNAME).$(($domain).ToLower())"
-$Cert = Get-Certificate -Template WebServerExportPrivate -DnsName $IP,$ShortName,$FQDN -SubjectName "CN=$($FQDN)" -CertStoreLocation 'Cert:\LocalMachine\My\'
+
+$StopLoop = $false
+$RetryCount = 0
+
+do {
+  try {
+    $Cert = Get-Certificate -Template WebServerExportPrivate -DnsName $IP,$ShortName,$FQDN -SubjectName "CN=$($FQDN)" -CertStoreLocation 'Cert:\LocalMachine\My\'
+    $StopLoop = $true
+  }
+  catch {
+    if ($RetryCount -gt 5) {
+      Write-Host "Could not get certificate after 5 retries."
+      $StopLoop = $true
+    } else {
+      Write-Host "Could not get certificate, retrying in 30 seconds..."
+      Start-Sleep -Seconds 30
+      $RetryCount = $RetryCount + 1
+    }
+  }
+}
+while ($StopLoop -eq $false)
+
 $CertificateThumbprint = $Cert.Certificate.Thumbprint
 
 $listener = @{


### PR DESCRIPTION
Added retry logic to `setupWinRm.ps1` around the pulling of the certificate. This was to help mitigate issues around datetime difference between AD and the server just after provisioning.

The error that was being received was the following:
```
TerminatingError(Get-Certificate): "CertEnroll::CX509Enrollment::InitializeFromTemplateName: There is a time and/or date difference between the client and server. 0x80070576 (WIN32: 1398 ERROR_TIME_SKEW)"
Get-Certificate : CertEnroll::CX509Enrollment::InitializeFromTemplateName: There is a time and/or date difference 
between the client and server. 0x80070576 (WIN32: 1398 ERROR_TIME_SKEW)
```