### PR TITLE
Added interfaceAlias parameter to setupWinRm.ps1

### DIFF
--- a/setupWinRm.ps1
+++ b/setupWinRm.ps1
@@ -19,7 +19,7 @@ param
   [String]
   $rootCertName,
 
-  [Parameter(Mandatory = $True, Position = 3)]
+  [Parameter(Position = 3)]
   [String]
   $interfaceAlias = "Ethernet0*"
 )

--- a/setupWinRm.ps1
+++ b/setupWinRm.ps1
@@ -17,7 +17,11 @@ param
   [Parameter(Mandatory = $True, Position = 2)]
   [ValidateNotNullOrEmpty()]
   [String]
-  $rootCertName
+  $rootCertName,
+
+  [Parameter(Mandatory = $True, Position = 3)]
+  [String]
+  $interfaceAlias = "Ethernet0*"
 )
 
 Start-Transcript -Path C:\Temp\setupWinRm.log
@@ -45,7 +49,7 @@ while ($count -le 30) {
   }
 }
 
-$IP = (Get-NetIPAddress -InterfaceAlias "Ethernet0*" -AddressFamily IPv4).IPAddress
+$IP = (Get-NetIPAddress -InterfaceAlias $interfaceAlias -AddressFamily IPv4).IPAddress
 $ShortName = "$($Env:COMPUTERNAME)"
 $FQDN = "$($Env:COMPUTERNAME).$(($domain).ToLower())"
 


### PR DESCRIPTION
Added `interfaceAlias` parameter to setupWinRm parameter to account for interface alias differences in VM platforms.