### PR TITLE
Fix for wsman issue 659841

### DIFF
--- a/setupWinRm.ps1
+++ b/setupWinRm.ps1
@@ -79,7 +79,7 @@ $CertificateThumbprint = $Cert.Certificate.Thumbprint
 $listener = @{
    ResourceURI = "winrm/config/Listener"
    SelectorSet = @{Address="*";Transport="HTTPS"}
-   ValueSet = @{CertificateThumbprint=$CertificateThumbprint}
+   ValueSet = @{CertificateThumbprint=$CertificateThumbprint;Hostname=$FQDN}
  }
  
  Set-WSManInstance @listener


### PR DESCRIPTION
The $FQDN variable is already computed earlier in the script and used in the certificate SAN — this change passes it through to the listener configuration.